### PR TITLE
Use the respec-w3c profile

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
 <head>
 <meta charset="utf-8">
 <title>Rules for Simple Placement of Japanese Ruby</title>
-<script src="https://www.w3.org/Tools/respec/respec-w3c-common" class="remove"></script> 
+<script src="https://www.w3.org/Tools/respec/respec-w3c" class="remove"></script> 
 <script class="remove">
       var respecConfig = {
         specStatus: "ED",


### PR DESCRIPTION
The `w3c-common` profile was no longer updated.
See https://github.com/w3c/respec/pull/2838 for details.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/simple-ruby/pull/41.html" title="Last updated on Jul 16, 2020, 8:53 AM UTC (86c0db8)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/simple-ruby/41/14e8de4...86c0db8.html" title="Last updated on Jul 16, 2020, 8:53 AM UTC (86c0db8)">Diff</a>