### PR TITLE
Use the `group` configuration option

### DIFF
--- a/index.html
+++ b/index.html
@@ -31,9 +31,7 @@
           },
         },
         noRecTrack: true,
-        wg: "Internationalization Working Group",
-        wgURI: "https://www.w3.org/International/core/",
-        wgPatentURI: "https://www.w3.org/2004/01/pp-impl/32113/status",
+        group: "i18n",
       };
     </script>
 <link rel="stylesheet" href="https://www.w3.org/StyleSheets/TR/2016/base.css">


### PR DESCRIPTION
The wg, wgId, wgURI, and wgPatentURI options are deprecated in favour of
“group”.

See https://lists.w3.org/Archives/Public/spec-prod/2020JulSep/0002.html


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/simple-ruby/pull/43.html" title="Last updated on Jul 23, 2020, 3:48 AM UTC (a353554)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/simple-ruby/43/ff1d01b...a353554.html" title="Last updated on Jul 23, 2020, 3:48 AM UTC (a353554)">Diff</a>