### PR TITLE
jukugo-ruby, the start / the end pair

### DIFF
--- a/index.html
+++ b/index.html
@@ -257,7 +257,7 @@ annotation and its base text, collectively,  as the <dfn>ruby block</dfn>.</p>
 
 <p>Ruby in Japanese may be divided into the following 3 different types,
 based on the relationship between the ruby and the base characters
-(see <a href="https://www.w3.org/TR/jlreq/#usage_of_ruby">JLReq “3.3.1 Usage of Ruby”</a>.</p>
+(see <a href="https://www.w3.org/TR/jlreq/#usage_of_ruby">JLReq “3.3.1 Usage of Ruby”</a>).</p>
 <ol>
 <li id="l20200529012">Mono-ruby</li>
 <li id="l20200529013">Jukugo-ruby</li>
@@ -477,7 +477,7 @@ Western characters together rather than aligning lengths, and uses no method for
 <figcaption>Example 2 of group-ruby.</figcaption>
 </figure>
 
-<p>However, the size of the spacing inserted at the start and end must
+<p>However, the size of the spacing inserted at the start and the end must
         be capped at no more than half the size of one base character,
         and the spacing inserted between each ruby character is enlarged to compensate (see [[[#group-3]]]).</p>
 		
@@ -544,7 +544,7 @@ Western characters together rather than aligning lengths, and uses no method for
     the base text 
     is handled in the same way as for mono-ruby
     (see [[[#protruding-group]]]).
-    Also, when the ruby annotation is wider than its base character string and extends beyond it and is located at the start or end of the line,
+    Also, when the ruby annotation is wider than its base character string and extends beyond it and is located at the start or the end of the line,
     the resulting layout is also identical to that for mono-ruby.</p>
 <figure id="protruding-group">
 <img src="img/fig17.svg" alt="" style="min-width: 14em;" />
@@ -620,7 +620,7 @@ Western characters together rather than aligning lengths, and uses no method for
 <p>With jukugo-ruby, individual base texts and their associated ruby annotations are treated as a unit,
     and line wrap opportunities are allowed between two base texts.
     When such a line wrap occurs,
-    if a single base text that is part of the jukugo is placed alone at the end or at the start of a line,
+    if a single base text that is part of the jukugo-ruby is placed alone at the end or at the start of a line,
     it is laid out identically to mono-ruby;
     conversely when several base texts that are part of the jukugo
     are placed together at the end or start of a line,
@@ -636,7 +636,7 @@ Western characters together rather than aligning lengths, and uses no method for
     the base text 
     is handled in the same way as for mono-ruby.
     Also, when the ruby annotation is wider than its base text,
-    extends beyond it, and is located at the start or end of the line,
+    extends beyond it, and is located at the start or the end of the line,
     the resulting layout is also identical to that of mono-ruby.</li>
 </ol>
 </section>

--- a/index.html
+++ b/index.html
@@ -623,7 +623,7 @@ Western characters together rather than aligning lengths, and uses no method for
     if a single base text that is part of the jukugo-ruby is placed alone at the end or at the start of a line,
     it is laid out identically to mono-ruby;
     conversely when several base texts that are part of the jukugo
-    are placed together at the end or start of a line,
+    are placed together at the end or the start of a line,
     they are laid out together as has been described in this section about jukugo-ruby
     (see [[[#wrap-jukugo]]]).</p>
 <figure id="wrap-jukugo">


### PR DESCRIPTION
minor editorial fixes


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/himorin/simple-ruby/pull/48.html" title="Last updated on Aug 20, 2020, 7:51 AM UTC (4f8e2fa)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/simple-ruby/48/ff1d01b...himorin:4f8e2fa.html" title="Last updated on Aug 20, 2020, 7:51 AM UTC (4f8e2fa)">Diff</a>