### PR TITLE
updated three 'see also'-s

### DIFF
--- a/index.html
+++ b/index.html
@@ -104,7 +104,7 @@ and sometimes these approaches can be very complex. Ruby is one such case. There
 
 <aside class="note" title="Ruby and interlinear notes" id="n20200529001"> Interlinear notes are sometimes placed between lines
       in the same position as ruby annotations
-      (see also JLReq <a href="https://www.w3.org/TR/jlreq/#fig3_2_8">Figure 241: An example of a note in inter lines</a> for examples).
+      (see also <a href="https://www.w3.org/TR/jlreq/#fig3_2_8">an example of an interlinear note in JLReq</a>).
       These inter-linear notes are not covered in this document.
       Line breaks are not allowed inside mono-ruby annotations, and, for group-ruby, line-breaks are not allowed in the ruby base. 
       In contrast, interlinear notes may involve a large number of characters, 
@@ -134,7 +134,7 @@ in order to decide on the placement:</p>
     and whether this affects the position of the base text.</p>
 
 <aside class="note" title="Ruby annotations that are wider than the base text" id="n20200529002">
-<p>Since Japanese composition seeks to avoid spacing between characters as much as possible (see also JLReq <a href="https://www.w3.org/TR/jlreq/#principles_of_arrangement_of_kanji_and_kana_characters">section "Principles of Arrangement of Kanji and Kana Characters"</a>), ruby annotations wider than their base characters are not allowed to overhang neighboring kanji, but often <em>are</em> allowed to overhang neighboring kana. 
+<p>Since Japanese composition seeks to avoid spacing between characters as much as possible (see the description of '<a href="https://www.w3.org/TR/jlreq/#principles_of_arrangement_of_kanji_and_kana_characters">solid setting</a>' in [[JLREQ]]), ruby annotations wider than their base characters are not allowed to overhang neighboring kanji, but often <em>are</em> allowed to overhang neighboring kana. 
       This method works well when characters preceding and following 
       the ruby base are both kana
       or both kanji. 
@@ -291,7 +291,7 @@ and their placement in the inline direction relative to the base characters is a
 <li id="l20200529016">In vertical text, ruby annotation is placed to the right of the base characters,
     and the character frame of the ruby annotation is placed flush
     against the character frame of the base characters.
-	(See also JLReq <a href="https://www.w3.org/TR/jlreq/#kanji_hiragana_and_katakana">section 2.1.2 Kanji, Hiragana and Katakana</a> for details on character frame.)
+	(The '<a href="https://www.w3.org/TR/jlreq/#kanji_hiragana_and_katakana">character frame</a>' is described in [[JLREQ]].)
 <figure>
 <img src="img/fig05.svg" alt="" style="width: 20%; min-width: 10em;" />
 <figcaption>Example of vertical ruby.</figcaption>


### PR DESCRIPTION
Updated ones in PR #47 per three comments: https://github.com/w3c/simple-ruby/pull/47#pullrequestreview-540861498 etc.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/himorin/simple-ruby/pull/50.html" title="Last updated on Feb 1, 2021, 1:51 PM UTC (fc9754c)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/simple-ruby/50/ea0ba74...himorin:fc9754c.html" title="Last updated on Feb 1, 2021, 1:51 PM UTC (fc9754c)">Diff</a>