### PR TITLE
added lines from Bin-sensei's update (C-#44-6)

### DIFF
--- a/index.html
+++ b/index.html
@@ -398,7 +398,11 @@ points 1, 2, and 3 belong to the first step, and points 4 and 5 belong to the se
  (see [[[#line-start-mono]]]),
  while if the annotation falls at the end of the line,
  then the end of the ruby annotation is aligned with the line’s end edge
- (see [[[#line-end-mono]]]).</p>
+ (see [[[#line-end-mono]]]).
+ Although spacing could be inserted between ruby base and the line edge following this rule, 
+ results of placement are allowed if ruby annotation is aligned with the line edge. 
+ This rule was used in [[?JISX4051]] and also in real cases.
+</p>
  
 <figure id="line-start-mono"> <img src="img/fig10.svg" alt="" style="min-width: 11em;" />
 <figcaption>Example of mono-ruby at the line start.</figcaption>

--- a/index.html
+++ b/index.html
@@ -399,9 +399,7 @@ points 1, 2, and 3 belong to the first step, and points 4 and 5 belong to the se
  while if the annotation falls at the end of the line,
  then the end of the ruby annotation is aligned with the line’s end edge
  (see [[[#line-end-mono]]]).
- Although spacing could be inserted between ruby base and the line edge following this rule, 
- results of placement are allowed if ruby annotation is aligned with the line edge. 
- This rule was used in [[?JISX4051]] and also in real cases.
+This rule allows a gap between the ruby base and the line edge as long as the ruby annotation touches. [[?JISX4051]] adopts this rule.
 </p>
  
 <figure id="line-start-mono"> <img src="img/fig10.svg" alt="" style="min-width: 11em;" />


### PR DESCRIPTION
added lines to address #46 point 6, for allowing spacing between the line edge and ruby base
https://lists.w3.org/Archives/Public/public-i18n-japanese/2021OctDec/0119.html

<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/himorin/simple-ruby/pull/66.html" title="Last updated on Nov 18, 2021, 11:48 AM UTC (7f9b966)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/simple-ruby/66/8c0efc9...himorin:7f9b966.html" title="Last updated on Nov 18, 2021, 11:48 AM UTC (7f9b966)">Diff</a>


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/himorin/simple-ruby/pull/66.html" title="Last updated on May 12, 2023, 5:59 AM UTC (fe45cc6)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/simple-ruby/66/8c0efc9...himorin:fe45cc6.html" title="Last updated on May 12, 2023, 5:59 AM UTC (fe45cc6)">Diff</a>