### PR TITLE
updated note per comment (C-#44-4)

### DIFF
--- a/index.html
+++ b/index.html
@@ -550,10 +550,17 @@ Western characters together rather than aligning lengths, and uses no method for
     are treated as a unit, 
     so there is no line wrapping opportunity inside either string.</p>
 	
-<aside class="note" title="Wrap opportunities in group-ruby" id="n20200529006">
+<aside class="note" title="Line wrapping in group-ruby" id="n20200529006">
 <p>As group-ruby is treated as a single unit, there is no wrap opportunity.
       However, there are examples where allowing wrapping may be desirable.
       In such cases, based on appropriate association of base text and ruby annotations, it may be appropriate to handle the wrapping opportunities in the same way as for jukugo-ruby.</p>
+<p>As <a title="group-ruby">group-ruby</a> is treated as a single unit, there is no wrap opportunity. 
+However, in letterpress printing, there are cases to introduce line wrapping within <a title="group-ruby">group-ruby</a> 
+in cases like compound words, 
+since there were cases to make extream placement results by line alignment. 
+Considering this, it is desired to allow line wrapping in <a title="group-ruby">group-ruby</a> 
+with considering combinations of characters of ruby annotation and base text. 
+</p>
 <figure id="wrap-group">
 <img src="img/fig18.svg" alt="" style="min-width: 25em;" />
 <figcaption>Wrapping group-ruby.</figcaption>

--- a/index.html
+++ b/index.html
@@ -551,9 +551,6 @@ Western characters together rather than aligning lengths, and uses no method for
     so there is no line wrapping opportunity inside either string.</p>
 	
 <aside class="note" title="Line wrapping in group-ruby" id="n20200529006">
-<p>As group-ruby is treated as a single unit, there is no wrap opportunity.
-      However, there are examples where allowing wrapping may be desirable.
-      In such cases, based on appropriate association of base text and ruby annotations, it may be appropriate to handle the wrapping opportunities in the same way as for jukugo-ruby.</p>
 <p>As <a title="group-ruby">group-ruby</a> is treated as a single unit, there is no wrap opportunity. 
 However, in letterpress printing, there are cases to introduce line wrapping within <a title="group-ruby">group-ruby</a> 
 in cases like compound words, 


### PR DESCRIPTION
replaced note with updated note by Bin-sensei.
https://lists.w3.org/Archives/Public/public-i18n-japanese/2021OctDec/0114.html

<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/himorin/simple-ruby/pull/68.html" title="Last updated on Nov 25, 2021, 2:58 AM UTC (b53c845)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/simple-ruby/68/8c0efc9...himorin:b53c845.html" title="Last updated on Nov 25, 2021, 2:58 AM UTC (b53c845)">Diff</a>


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/himorin/simple-ruby/pull/68.html" title="Last updated on Mar 15, 2022, 8:20 AM UTC (b53c845)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/simple-ruby/68/8c0efc9...himorin:b53c845.html" title="Last updated on Mar 15, 2022, 8:20 AM UTC (b53c845)">Diff</a>