### PR TITLE
turn note into main text in double-sided ruby section (C-46-10)

### DIFF
--- a/index.html
+++ b/index.html
@@ -649,9 +649,11 @@ As we are using <a href="#l20200529009">two-step processing</a>, consideration o
 extend beyond the ruby base text and their relationship with preceding and following 
 characters, or placement at the line head or the line end, are processed in 
 the same way as when the ruby string is annotations on one side only. </p>
+</section>
 
-<p>Also considerations for space between adjacent lines with double-sided ruby are required. 
-When two adjacent rows have double-sided ruby, the configuration of the inter-line spacing could cause an undesirable overlap of two ruby annotations. 
+<section>
+<h3 id="space-between-adjacent-lines-and-double-sided-ruby">Space between adjacent lines and double-sided ruby</h3>
+<p>When two adjacent rows have double-sided ruby, the configuration of the inter-line spacing could cause an undesirable overlap of two ruby annotations. 
 The following methods could be applied to avoid such cases:</p>
 <ol>
 <li id="l20200529042">Configure the space between lines across the whole document in advance to avoid 

--- a/index.html
+++ b/index.html
@@ -650,8 +650,8 @@ extend beyond the ruby base text and their relationship with preceding and follo
 characters, or placement at the line head or the line end, are processed in 
 the same way as when the ruby string is annotations on one side only. </p>
 
-<aside class="note" title="Space between adjacent lines and double-sided ruby" id="n20200529007">
-<p>When two adjacent rows have double-sided ruby, the configuration of the inter-line spacing could cause an undesirable overlap of two ruby annotations. 
+<p>Also considerations for space between adjacent lines with double-sided ruby are required. 
+When two adjacent rows have double-sided ruby, the configuration of the inter-line spacing could cause an undesirable overlap of two ruby annotations. 
 The following methods could be applied to avoid such cases:</p>
 <ol>
 <li id="l20200529042">Configure the space between lines across the whole document in advance to avoid 
@@ -672,7 +672,6 @@ In automatic processing used for the Web documents, the third method might be
 suitable. Using the third method in an area with an integral number of line spaces around it
 (for example, centering across a two line space) limits the disruption to that line, and maintains the alignment of lines against those in any adjacent column. 
 (See also <a href="https://www.w3.org/TR/jlreq/#adjustment_of_processing_of_realm_in_block_direction">JLReq "Adjustment of Processing of Realm in Block Direction"</a>.)</p>
-</aside>
 </section>
 
 


### PR DESCRIPTION
turn note in 4.1 double-sided ruby section as main text.
https://lists.w3.org/Archives/Public/public-i18n-japanese/2021OctDec/0105.html

<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/himorin/simple-ruby/pull/73.html" title="Last updated on Nov 29, 2021, 6:39 AM UTC (1f60903)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/simple-ruby/73/8c0efc9...himorin:1f60903.html" title="Last updated on Nov 29, 2021, 6:39 AM UTC (1f60903)">Diff</a>


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/himorin/simple-ruby/pull/73.html" title="Last updated on Mar 15, 2022, 8:13 AM UTC (1f60903)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/simple-ruby/73/8c0efc9...himorin:1f60903.html" title="Last updated on Mar 15, 2022, 8:13 AM UTC (1f60903)">Diff</a>