### PR TITLE
turned div into section for abstract and sotd

### DIFF
--- a/index.html
+++ b/index.html
@@ -61,10 +61,10 @@
 </style>
 </head>
 <body>
-<div id="abstract">
+<section id="abstract">
 <p>A simple set of rules for placement of Ruby text in Japanese typography.</p>
-</div>
-<div id="sotd">
+</section>
+<section id="sotd">
 <p> This document was initially written in Japanese
   and translated to English
   by the <a href="https://www.aplab.jp/jwt">Japanese Writing Technology</a> Working Group
@@ -76,7 +76,7 @@
   with this particular approach,
   and to encourage discussion of this topic. </p>
 <p>The original Japanese version is <a href="ruby-rules-ja.pdf">available in PDF format</a>.</p>
-</div>
+</section>
 
 
 


### PR DESCRIPTION
not sure why, but abstract and SoTD were wrapped by div but not section as specified in respec ([example in documentation](https://respec.org/docs/#example-a-basic-respec-document)). Could be just following old possible way of respec, but this fixes as using section.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/himorin/simple-ruby/pull/78.html" title="Last updated on Jan 14, 2022, 8:45 AM UTC (8b4f652)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/simple-ruby/78/8c0efc9...himorin:8b4f652.html" title="Last updated on Jan 14, 2022, 8:45 AM UTC (8b4f652)">Diff</a>