### PR TITLE
replaced two-step processing part

### DIFF
--- a/index.html
+++ b/index.html
@@ -213,7 +213,7 @@ annotation and its base text, collectively,  as the <dfn>ruby box</dfn>.</p>
     In the first level, processing of layout only considers the relative position of the ruby annotation and its base text. 
     In the second level, layout processing decides the position of the <a>ruby box</a> in the line. 
     In other words, relative positions of the ruby annotation and its base text as decided in the first level 
-    are not modified by the second level in light of any characters or line edge preceding and following the <a>ruby box</a>.
+    are not modified by the second level such as in light of any characters or line edge preceding and following the <a>ruby box</a>.
     Two levels are processed as following, with using <dfn>ruby column</dfn> for paired ruby annotation and its base text, 
     and untransparent <a>ruby box</a> for <a>ruby box</a> with their relative position:
     <ol>

--- a/index.html
+++ b/index.html
@@ -213,7 +213,7 @@ annotation and its base text, collectively,  as the <dfn>ruby box</dfn>.</p>
     In the first level, processing of layout only considers the relative position of the ruby annotation and its base text. 
     In the second level, layout processing decides the position of the <a>ruby box</a> in the line. 
     In other words, relative positions of the ruby annotation and its base text as decided in the first level 
-    are not modified in light of any characters or line edge preceding and following the <a>ruby box</a>.
+    are not modified by the second level in light of any characters or line edge preceding and following the <a>ruby box</a>.
     Two levels are processed as following, with using <dfn>ruby column</dfn> for paired ruby annotation and its base text, 
     and untransparent <a>ruby box</a> for <a>ruby box</a> with their relative position:
     <ol>

--- a/index.html
+++ b/index.html
@@ -217,7 +217,7 @@ annotation and its base text, collectively,  as the <dfn>ruby box</dfn>.</p>
     Two levels are processed as following, with using <dfn>ruby column</dfn> for paired ruby annotation and its base text, 
     and untransparent <a>ruby box</a> for <a>ruby box</a> with their relative position:
     <ol>
-    <li id="l20220318001">The first level takes a <a>ruby column</a>> with required parameters for 
+    <li id="l20220318001">The first level takes a <a>ruby column</a> with required parameters for 
         processing placement for inline direction inluding available space within the current line 
         but without any preceding or following characters, 
         and outputs one or more untransparent <a>ruby box</a>.</li>

--- a/index.html
+++ b/index.html
@@ -193,13 +193,13 @@ so that placement may be determined fully automatically.</p>
 <h3 id="matters-considered-by-the-placement-rules">Considerations for  simple placement rules</h3>
 
 <p>Here are the fundamental assumptions underlying the simple placement rules.  In this document we refer to the ruby 
-annotation and its base text, collectively,  as the <dfn>ruby block</dfn>.</p>
+annotation and its base text, collectively,  as the <dfn>ruby box</dfn>.</p>
 <ol>
 <li id="l20200529007">
 <p>Ruby is used to display the reading or the meaning of the base characters.
     Therefore, the number one priority here is to avoid misreadings.
     Specifically, this method does not allow a ruby annotation which is wider than its base text to overhang the characters preceding or 
-    following the <a title="ruby block">ruby block</a>, whether they are kanji or kana characters.</p>
+    following the <a>ruby box</a>, whether they are kanji or kana characters.</p>
 	
 <aside class="note" title="Overhanging surrounding characters" id="n20200529003"> The main placement method defined in [[JISX4051]]
       allows some amount of overhang over the preceding and following base characters,
@@ -209,18 +209,22 @@ annotation and its base text, collectively,  as the <dfn>ruby block</dfn>.</p>
     and will use the same logic in either case.
     Specifically, the center of the ruby string and of the base character 
     string are aligned in the inline direction for mono-ruby.</li>
-<li id="l20200529009">Processing is done in two steps. 
-    In the first step, processing of layout only considers  the relative positions of the ruby 
-    annotation and its base text. 
-    In the second step,  layout processing decides the position of the <a title="ruby block">ruby block</a> in the line, taking into consideration the preceding and 
-    following characters. In other words relative positions of the ruby annotation and its base text as decided in the first step are not modified 
-    in  light of any characters preceding and following the ruby block. 
-    Also, when the ruby block is placed at 
-    the line head or the line end the method used in this document does not align the first or last 
-    character of the base text to the line head or the line 
-    end by modifying the relative positions of the ruby annotation and its base text. 
-    To summarise, the relative positions decided in the first step are not 
-    modified by the second step at all.</li>
+<li id="l20200529009">Processing is done in two levels.
+    In the first level, processing of layout only considers the relative position of the ruby annotation and its base text. 
+    In the second level, layout processing decides the position of the <a>ruby box</a> in the line. 
+    In other words, relative positions of the ruby annotation and its base text as decided in the first level 
+    are not modified in light of any characters or line edge preceding and following the <a>ruby box</a>.
+    Two levels are processed as following, with using <dfn>ruby column</dfn> for paired ruby annotation and its base text, 
+    and untransparent <a>ruby box</a> for <a>ruby box</a> with their relative position:
+    <ol>
+    <li id="l20220318001">The first level takes a <a>ruby column</a>> with required parameters for 
+        processing placement for inline direction inluding available space within the current line 
+        but without any preceding or following characters, 
+        and outputs one or more untransparent <a>ruby box</a>.</li>
+    <li id="l20220318002">The second level takes a size and preceding and following text of <a>ruby boxes</a>, 
+        and outputs styled text.</li>
+    </ol>
+</li>
 <li id="l20200529010">Although there are cases where  [[JLREQ]] 
     and [[JISX4051]] list multiple ways of positioning ruby, this document only describes one method, based on 
     the policies described above. 
@@ -319,8 +323,8 @@ it is explained last.</p>
 
 <section>
 <h3 id="placement-of-mono-ruby">Placement of mono-ruby</h3>
-<p>To align the following items to the <a href="#l20200529009">two-step processing method</a> described in [[[#matters-considered-by-the-placement-rules]]], 
-points 1, 2, and 3 belong to the first step, and points 4 and 5 belong to the second.</p>
+<p>To align the following items to the <a href="#l20200529009">two-level processing method</a> described in [[[#matters-considered-by-the-placement-rules]]], 
+points 1, 2, and 3 belong to the first level, and points 4 and 5 belong to the second.</p>
 <ol>
 <li id="l20200529018">
 <p>When the ruby annotation consists of two or more characters,
@@ -432,7 +436,7 @@ both are laid out without inter-character spacing
 and placed such that their respective centers are aligned in the inline direction
 (see [[[#group-ruby]]]).
 For other cases, the placement depends on the following.</p>
-<p>In terms of the above-mentioned two-step processing method  described in [[[#matters-considered-by-the-placement-rules]]], points (1), (2) and (3)  belong to the first step, and (4) and (5) to the second.</p>
+<p>In terms of the above-mentioned two-level processing method  described in [[[#matters-considered-by-the-placement-rules]]], points (1), (2) and (3)  belong to the first level, and (4) and (5) to the second.</p>
 
 <aside class="note" title="Inter-character spacing in group-ruby" id="n20200529005">For group-ruby, it is preferred for the length of ruby annotation and the length of its base text to be aligned, but the lengths may differ 
 by a number of characters. When the annotation is composed of <a title="japanese characters">Japanese characters</a>, to compensate for the difference,  space is added before, after, and between the characters of the ruby annotation, or those of the base 
@@ -572,7 +576,7 @@ with considering combinations of characters of ruby annotation and base text.
 
 <section>
 <h3 id="placement-of-jukugo-ruby">Placement of Jukugo-ruby</h3>
-<p>In terms of the above-mentioned two-step processing method  described in [[[#matters-considered-by-the-placement-rules]]], points (1), (2) and (3)  belong to the first step, and (4)  to the second.</p>
+<p>In terms of the above-mentioned two-level processing method  described in [[[#matters-considered-by-the-placement-rules]]], points (1), (2) and (3)  belong to the first level, and (4)  to the second.</p>
 <ol>
 <li id="l20200529036">
 <p>With jukugo-ruby, each base text is associated with its own ruby annotation.
@@ -649,7 +653,7 @@ with considering combinations of characters of ruby annotation and base text.
 <h3 id="placement-of-double-sided-ruby-by-combination-of-type-of-ruby">Placement of double-sided ruby by combinations of ruby types</h3>
 <p> Quite complex methods are required to apply the full rules for placement of double-sided ruby. For simple placement of double-sided ruby, rules can be written for each of the 
 combinations of mono-ruby, group-ruby, and jukugo-ruby for two sides. 
-As we are using <a href="#l20200529009">two-step processing</a>, consideration of  ruby annotations that 
+As we are using <a href="#l20200529009">two-level processing</a>, consideration of  ruby annotations that 
 extend beyond the ruby base text and their relationship with preceding and following 
 characters, or placement at the line head or the line end, are processed in 
 the same way as when the ruby string is annotations on one side only. </p>

--- a/index.html
+++ b/index.html
@@ -214,7 +214,7 @@ annotation and its base text, collectively,  as the <dfn>ruby box</dfn>.</p>
     Meanwhile, the second level determines inline positions of <a>ruby boxes</a>. 
     In other words, relative positions of the ruby annotation and its base text as decided in the first level 
     are not modified by the second level such as in light of any characters or line edge preceding and following the <a>ruby box</a>.
-    Two levels are processed as following:
+    Two levels are processed as follows:
     <ol>
     <li id="l20220318001">The first level takes pairs of ruby annotation and its base text 
         and parameters required for procesing such as available space in inline direction in the current line, 

--- a/index.html
+++ b/index.html
@@ -210,17 +210,20 @@ annotation and its base text, collectively,  as the <dfn>ruby box</dfn>.</p>
     Specifically, the center of the ruby string and of the base character 
     string are aligned in the inline direction for mono-ruby.</li>
 <li id="l20200529009">Processing is done in two levels.
-    The first level only determines relative positions of ruby annotation and its base. 
-    Meanwhile, the second level determines inline positions of <a>ruby boxes</a>. 
-    In other words, relative positions of the ruby annotation and its base text as decided in the first level 
-    are not modified by the second level such as in light of any characters or line edge preceding and following the <a>ruby box</a>.
-    Two levels are processed as follows:
+    The first level only determines relative positions of ruby annotation and its base.
+    Meanwhile, the second level determines inline positions of <a>ruby boxes</a>.
+    In other words, relative positions of the ruby annotation and its base text as decided in the first level
+    are not referenced nor modified by the second level such as in light of any characters or line edge preceding and following the <a>ruby box</a>, 
+    except for hanging length of the ruby annotation from its base text when the ruby annotation is wider than its base text 
+    which may be used by the second level for removing spacing of the characters preceding or following the <a>ruby box</a>.
+    Two levels are processed as following:
     <ol>
-    <li id="l20220318001">The first level takes pairs of ruby annotation and its base text 
-        and parameters required for procesing such as available space in inline direction in the current line, 
-        but does not take any preceding or following characters. 
-        The first level outputs one or more untransparent <a>ruby boxes</a>, which have relative position of ruby annotation to its base.</li>
-    <li id="l20220318002">The second level takes a size of untransparent <a>ruby box</a> and its preceding and following text, 
+    <li id="l20220318001">The first level takes pairs of ruby base and its annotation
+        including parameters needed for processing, such as available space in the inline direction of the current line,
+        but excluding any preceding or following characters to the ruby base.
+        The first level outputs one or more <a>ruby boxes</a>, that indicate the outside size of <a>ruby boxes</a>
+        and the position of the ruby annotation with respect to its base.</li>
+    <li id="l20220318002">The second level looks at the outside size of <a>ruby box</a> and its surrounding text,
         and outputs styled text.</li>
     </ol>
 </li>

--- a/index.html
+++ b/index.html
@@ -210,18 +210,17 @@ annotation and its base text, collectively,  as the <dfn>ruby box</dfn>.</p>
     Specifically, the center of the ruby string and of the base character 
     string are aligned in the inline direction for mono-ruby.</li>
 <li id="l20200529009">Processing is done in two levels.
-    In the first level, processing of layout only considers the relative position of the ruby annotation and its base text. 
-    In the second level, layout processing decides the position of the <a>ruby box</a> in the line. 
+    The first level only determines relative positions of ruby annotation and its base. 
+    Meanwhile, the second level determines inline positions of <a>ruby boxes</a>. 
     In other words, relative positions of the ruby annotation and its base text as decided in the first level 
     are not modified by the second level such as in light of any characters or line edge preceding and following the <a>ruby box</a>.
-    Two levels are processed as following, with using <dfn>ruby column</dfn> for paired ruby annotation and its base text, 
-    and untransparent <a>ruby box</a> for <a>ruby box</a> with their relative position:
+    Two levels are processed as following:
     <ol>
-    <li id="l20220318001">The first level takes a <a>ruby column</a> with required parameters for 
-        processing placement for inline direction inluding available space within the current line 
-        but without any preceding or following characters, 
-        and outputs one or more untransparent <a>ruby box</a>.</li>
-    <li id="l20220318002">The second level takes a size and preceding and following text of <a>ruby boxes</a>, 
+    <li id="l20220318001">The first level takes pairs of ruby annotation and its base text 
+        and parameters required for procesing such as available space in inline direction in the current line, 
+        but does not take any preceding or following characters. 
+        The first level outputs one or more untransparent <a>ruby boxes</a>, which have relative position of ruby annotation to its base.</li>
+    <li id="l20220318002">The second level takes a size of untransparent <a>ruby box</a> and its preceding and following text, 
         and outputs styled text.</li>
     </ol>
 </li>


### PR DESCRIPTION
closes #74, NOTE: conflicts to #75

use `ruby box` and `two level`, with new text from Bin-sensei.
still wip.

original Japanese text: https://lists.w3.org/Archives/Public/public-i18n-japanese/2022JanMar/0037.html
but could be updated later.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/himorin/simple-ruby/pull/84.html" title="Last updated on Apr 20, 2023, 6:53 AM UTC (118462c)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/simple-ruby/84/bce1a03...himorin:118462c.html" title="Last updated on Apr 20, 2023, 6:53 AM UTC (118462c)">Diff</a>