### PR TITLE
Fix links to Katakana

### DIFF
--- a/index.html
+++ b/index.html
@@ -508,7 +508,7 @@ This rule allows a gap between the ruby base and the line edge as long as the ru
 and include characters like <a href="https://www.w3.org/TR/jlreq/#cl-24">Grouped numerals (cl-24)</a>, <a href="https://www.w3.org/TR/jlreq/#cl-25">Unit symbols (cl-25)</a>, <a href="https://www.w3.org/TR/jlreq/#cl-26">Western word space (cl-26)</a>,
 and <a href="https://www.w3.org/TR/jlreq/#cl-27">Western characters (cl-27)</a>. <dfn>Japanese characters</dfn> have fixed fullwidth 
 size 
-and includes characters like <a href="https://www.w3.org/TR/jlreq/#cl-15">Hiragana (cl-15)</a>, <a href="https://www.w3.org/TR/jlreq/#cl-26">Katakana (cl-16)</a>, and <a href="https://www.w3.org/TR/jlreq/#cl-19">Ideographic characters (cl-19)</a> (see also <a href="https://w3c.github.io/jlreq/#kanji_hiragana_and_katakana">2.1.2 Kanji, Hiragana and Katakana</a>). <a title="western characters">Western characters</a> are read as clusters of multiple characters, and 
+and includes characters like <a href="https://www.w3.org/TR/jlreq/#cl-15">Hiragana (cl-15)</a>, <a href="https://www.w3.org/TR/jlreq/#cl-16">Katakana (cl-16)</a>, and <a href="https://www.w3.org/TR/jlreq/#cl-19">Ideographic characters (cl-19)</a> (see also <a href="https://w3c.github.io/jlreq/#kanji_hiragana_and_katakana">2.1.2 Kanji, Hiragana and Katakana</a>). <a title="western characters">Western characters</a> are read as clusters of multiple characters, and 
 it is desirable to avoid adding spacing between characters for justification. 
 The way items are positioned depends
 on how their respective lengths would
@@ -962,7 +962,7 @@ This document uses the option 1.</p>
 <a title="jukugo-ruby">jukugo-ruby</a>, 
 for when option 2 is used, 
 there is a method to apply option 1 only in case of all characters of ruby annotation 
-in <a href="https://www.w3.org/TR/jlreq/#cl-26">Katakana (cl-16)</a>.</p>
+in <a href="https://www.w3.org/TR/jlreq/#cl-16">Katakana (cl-16)</a>.</p>
 </section>
 
 


### PR DESCRIPTION



<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/simple-ruby/pull/91.html" title="Last updated on May 15, 2023, 6:51 AM UTC (48d5a42)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/simple-ruby/91/80462c8...48d5a42.html" title="Last updated on May 15, 2023, 6:51 AM UTC (48d5a42)">Diff</a>